### PR TITLE
Update wListCtrl.nim

### DIFF
--- a/wNim/private/controls/wListCtrl.nim
+++ b/wNim/private/controls/wListCtrl.nim
@@ -356,9 +356,8 @@ proc insertItem*(self: wListCtrl, index: int, texts: openarray[string],
     image = wListImageNone, data: int = 0): int {.validate, discardable.} =
   ## Inserts an item, and sets the text of subitems in the mean time.
   if texts.len >= 1:
-    result = self.insertItem(index, texts[0], image, data)
-    for i in 1..<texts.len:
-      self.setItem(result, i, texts[i])
+    for i in texts:
+      result = self.insertItem(index, i, image, data)    
 
 proc appendItem*(self: wListCtrl, texts: openarray[string],
     image = wListImageNone, data: int = 0): int {.validate, discardable.} =


### PR DESCRIPTION
ListCtrl does not perform `appendItem(seq)`
```
import
  strformat, math, strutils, sequtils

import wNim
import winim


let app = App()
let frame = Frame(title="Dialog Demo", size=(760, 580))
frame.minSize = (560, 580)

let panel = Panel(frame)

let lst = ListCtrl(panel, style=wLcReport or wLcSortAscending, size=(610, 390), pos=(10, 10))
lst.insertColumn(0, "name")
lst.setColumnWidth(0, 610)
lst.enableAlternateRowColors(true)

lst.appendItem("fExists")

var fExists: seq[string]
for i in 0 .. 10:
  fExists.add(fmt"item{i:02d}")

lst.appendItem(fExists)

frame.center()
frame.show()
app.mainLoop()

```