### PR TITLE
expose getWeb() and browser to integrated with libp2p

### DIFF
--- a/wNim/private/controls/wWebView.nim
+++ b/wNim/private/controls/wWebView.nim
@@ -67,7 +67,7 @@ type
     cookie: DWORD
     refs: LONG
     ole: ptr IOleObject
-    browser: ptr IWebBrowser2
+    browser*: ptr IWebBrowser2
     dispatch: IDispatch
     clientSite: IOleClientSite
     inPlaceSiteEx: IOleInPlaceSiteEx
@@ -747,9 +747,9 @@ proc wWebViewClassInit(className: string) =
   wc.lpszClassName = className
   RegisterClassEx(wc)
 
-proc getWeb(self: wWebView): ptr wWeb =
+proc getWeb*(self: wWebView): ptr wWeb =
   result = cast[ptr wWeb](GetWindowLongPtr(self.mHwnd, 0))
-  assert result != nil
+  # assert result != nil
 
 method getDefaultSize*(self: wWebView): wSize {.property, uknlock.} =
   ## Returns the default size for the control.


### PR DESCRIPTION
There is a requirement of release resource for the else branch in webView.goBack()  in my application and here are corresponding two solutions which I can think of, one is adding a closure parameter like
```nim
proc goBack*(self: wWebView, action: proc()) {.validate, inline.} =
  ## Navigate back.
  let web = self.getWeb()
  if web.canGoBack:
    web.browser.GoBack()
  else:
    action()
```
another is exposing those and disable the assertion.  Which do you prefer?  BTW, this is really the best windows GUI framework in Nim, thanks for your contribution!